### PR TITLE
Improved python 3 compatibility, fixed some edge cases.

### DIFF
--- a/BalanceChecker.py
+++ b/BalanceChecker.py
@@ -1,62 +1,62 @@
+import codecs
+from six import moves
 
 # Imports the PyOTA library
 from iota import Iota
 
 
-numberOfAddresses = input("How many addresses should be generated and checked for balance on each seed? ")
-iotaNode = raw_input("""
+numberOfAddresses = int(moves.input("How many addresses should be generated and checked for balance on each seed? "))
+iotaNode = moves.input("""
 To use this script you must connect to a IOTA node. You can use your local node address "http://localhost:14265"
 if you have a full node running or you can connect to a remote node. You can finde remote nodes to connect to on
 http://iotasupport.com/lightwallet.shtml
 
-Please enter a node address to connect to:""")
+Please enter a node address to connect to: """)
 
 
-seedFile = open("inputSeeds.txt", "r")
-seeds = seedFile.read().splitlines()
-seedFile.close()
+with codecs.open("inputSeeds.txt", "r", 'ascii') as seedFile:
+    seeds = seedFile.read().splitlines()
 
 # Will take a list of seeds and calls the addressGenerator function for each seed
 def seedSelector ():
-	x = len(seeds) - 1
-	i = 0
-	while i <= x:
-		seed = seeds[i]
-		print("Checking seed " + seed + " for balance...")
-		addressGenerator(seed)
-		i += 1
-	else:
-		print ("Finished!!!")
+    x = len(seeds) - 1
+    i = 0
+    while i <= x:
+        seed = seeds[i].strip()
+        if seed:
+            print("Checking seed " + seed + " for balance...")
+            addressGenerator(seed.encode('ascii'))
+        i += 1
+    else:
+        print ("Finished!!!")
 
 
 # Generates addresses of a given seed using the "get_new_addresses()" function
 def addressGenerator(seed):
-		api = Iota(iotaNode, seed) # The iota nodes IP address must always be supplied, even if it actually isn't used in this case.
-		gna_result = api.get_new_addresses(count=numberOfAddresses) # This is the actual function to generate the address. 
-		addresses = gna_result['addresses']
-		total = 0
-		i = 0
-		while i < numberOfAddresses:
-			address = [addresses[i]]
-			balance = addressBalance(address)
-			print ("Address " + str(address[0]) + " has a balance of: " + str(balance))
-			total += balance
-			i += 1
-		if total > 0:
-			print ("The above addresses have a total balance of " + str(total) + " Iota tokens!!!")
-		else:
-			print ("No balance on those addresses!")
+    api = Iota(iotaNode, seed) # The iota nodes IP address must always be supplied, even if it actually isn't used in this case.
+    gna_result = api.get_new_addresses(count=numberOfAddresses) # This is the actual function to generate the address.
+    addresses = gna_result['addresses']
+    total = 0
+    i = 0
+    while i < numberOfAddresses:
+        address = [addresses[i]]
+        balance = addressBalance(address)
+        print ("Address " + str(address[0]) + " has a balance of: " + str(balance))
+        total += balance
+        i += 1
+    if total > 0:
+        print ("The above addresses have a total balance of " + str(total) + " Iota tokens!!!")
+    else:
+        print ("No balance on those addresses!")
 
 # Sends a request to the IOTA node and gets the current confirmed balance
 def addressBalance(address):
-	api = Iota(iotaNode)
-	gna_result = api.get_balances(address)
-	balance = gna_result['balances']
-	return (balance[0])
-	
+    api = Iota(iotaNode)
+    gb_result = api.get_balances(address)
+    balance = gb_result['balances']
+    return (balance[0])
+
 
 print ( "Checking balance on the first " + str(numberOfAddresses) + " addresses for " + str(len(seeds)) + " seeds!")
-print ("This can take a while...")		
+print ("This can take a while...")
 seedSelector()
-
-

--- a/BalanceChecker.py
+++ b/BalanceChecker.py
@@ -15,46 +15,46 @@ Please enter a node address to connect to: """)
 
 
 with codecs.open("inputSeeds.txt", "r", 'ascii') as seedFile:
-    seeds = seedFile.read().splitlines()
+	seeds = seedFile.read().splitlines()
 
 # Will take a list of seeds and calls the addressGenerator function for each seed
 def seedSelector ():
-    x = len(seeds) - 1
-    i = 0
-    while i <= x:
-        seed = seeds[i].strip()
-        if seed:
-            print("Checking seed " + seed + " for balance...")
-            addressGenerator(seed.encode('ascii'))
-        i += 1
-    else:
-        print ("Finished!!!")
+	x = len(seeds) - 1
+	i = 0
+	while i <= x:
+		seed = seeds[i].strip()
+		if seed:
+			print("Checking seed " + seed + " for balance...")
+			addressGenerator(seed.encode('ascii'))
+		i += 1
+	else:
+		print ("Finished!!!")
 
 
 # Generates addresses of a given seed using the "get_new_addresses()" function
 def addressGenerator(seed):
-    api = Iota(iotaNode, seed) # The iota nodes IP address must always be supplied, even if it actually isn't used in this case.
-    gna_result = api.get_new_addresses(count=numberOfAddresses) # This is the actual function to generate the address.
-    addresses = gna_result['addresses']
-    total = 0
-    i = 0
-    while i < numberOfAddresses:
-        address = [addresses[i]]
-        balance = addressBalance(address)
-        print ("Address " + str(address[0]) + " has a balance of: " + str(balance))
-        total += balance
-        i += 1
-    if total > 0:
-        print ("The above addresses have a total balance of " + str(total) + " Iota tokens!!!")
-    else:
-        print ("No balance on those addresses!")
+	api = Iota(iotaNode, seed) # The iota nodes IP address must always be supplied, even if it actually isn't used in this case.
+	gna_result = api.get_new_addresses(count=numberOfAddresses) # This is the actual function to generate the address.
+	addresses = gna_result['addresses']
+	total = 0
+	i = 0
+	while i < numberOfAddresses:
+		address = [addresses[i]]
+		balance = addressBalance(address)
+		print ("Address " + str(address[0]) + " has a balance of: " + str(balance))
+		total += balance
+		i += 1
+	if total > 0:
+		print ("The above addresses have a total balance of " + str(total) + " Iota tokens!!!")
+	else:
+		print ("No balance on those addresses!")
 
 # Sends a request to the IOTA node and gets the current confirmed balance
 def addressBalance(address):
-    api = Iota(iotaNode)
-    gb_result = api.get_balances(address)
-    balance = gb_result['balances']
-    return (balance[0])
+	api = Iota(iotaNode)
+	gb_result = api.get_balances(address)
+	balance = gb_result['balances']
+	return (balance[0])
 
 
 print ( "Checking balance on the first " + str(numberOfAddresses) + " addresses for " + str(len(seeds)) + " seeds!")

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # IOTA-Balanace-Checker
 
 ### Description:
-A simpel python script to generate the first X addresses of a seed and check there balances
+A simple python script to generate the first X addresses of a seed and check there balances
 
 
 ### Usage:
 
-Note: You need the PyOTA library installed for the script to work. You can install PyOTA with `pip install pyota`
+Note: You need the PyOTA and six libraries installed for the script to work.
+You can install them with `pip install -r requirements.txt`.
 
 1.) Replace the sample seeds in `inputSeeds.txt` with the seed(s) you want to check. 
 Only one seed per line and the seed may only contain upper case A-Z and 9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyota
+six


### PR DESCRIPTION
My IDE did something to the indents; I thought I fixed it, but GitHub still thinks I rewrote the entire script.  However, I'm pretty sure it's the same as what you posted /:

If you reload the PR with `?w=1` in the URL (<https://github.com/bahamapascal/IOTA-Balanace-Checker/pull/1/files?w=1>), it will ignore the whitespace changes, and you can see what I actually changed (:

- Ignore empty seeds and whitespace in `inputSeeds.txt`.
- Made types in `seeds` consistent between Python 2 and Python 3.
- Fixed unsafe eval from user input.
- Added `six` to project requirements and created `requirements.txt` file.